### PR TITLE
Switch to netif library for querying network interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,12 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-sha1"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
-
-[[package]]
 name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,7 +167,7 @@ dependencies = [
  "env_logger",
  "gethostname",
  "log",
- "network-interface",
+ "netif",
  "rand",
  "serde",
  "serde_with",
@@ -418,13 +412,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "network-interface"
-version = "0.1.2-beta"
-source = "git+https://github.com/EstebanBorai/network-interface.git?rev=6ef84799dc8232a7b5e6724b355e4f1739298a83#6ef84799dc8232a7b5e6724b355e4f1739298a83"
+name = "netif"
+version = "0.1.0"
+source = "git+https://github.com/bnoordhuis/netif.git?rev=9d5f620799f8e18175b3b255aed0646d02fda7d0#9d5f620799f8e18175b3b255aed0646d02fda7d0"
 dependencies = [
  "libc",
- "thiserror",
- "windows",
+ "winapi",
 ]
 
 [[package]]
@@ -466,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1004,48 +997,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7524f6f9074f6326a1c167cd3dc2ed4e6916648a1a55116d029620af9b65fb1"
-dependencies = [
- "const-sha1",
- "windows_gen",
- "windows_macros",
-]
-
-[[package]]
-name = "windows_gen"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be44a189bde96fc0e0cdd5b152b2d21c635c0c94c7d256aab4425477b2a2f37"
-dependencies = [
- "windows_quote",
- "windows_reader",
-]
-
-[[package]]
-name = "windows_macros"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1d78ce8a43d45b8da282383a2cb2ffcd5587cc3a9c341125d3181d2b701ede"
-dependencies = [
- "syn",
- "windows_gen",
- "windows_quote",
- "windows_reader",
-]
-
-[[package]]
-name = "windows_quote"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa2185b18a6164a3fa3ea2b6c92ebc1b60f532ae5a85c57408ba6a5a064913"
-
-[[package]]
-name = "windows_reader"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3daa5bd758f2f8f20cd93a79aedca20759779f43785fc77b08a4e8e1e5876bbb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ toml = "0.5.8"
 version = "3.0.0-rc.7"
 features = ["derive"]
 
+[dependencies.netif]
+git = "https://github.com/bnoordhuis/netif.git"
+rev = "9d5f620799f8e18175b3b255aed0646d02fda7d0"
+
 [dependencies.serde]
 version = "1.0.131"
 features = ["derive"]
@@ -32,9 +36,3 @@ features = ["base64", "macros"]
 [dependencies.trust-dns-client]
 version = "0.21.0-alpha.4"
 features = ["dnssec", "dnssec-ring"]
-
-# PR: https://github.com/EstebanBorai/network-interface/pull/1
-# Can switch back to crates.io after a release
-[dependencies.network-interface]
-git = "https://github.com/EstebanBorai/network-interface.git"
-rev = "6ef84799dc8232a7b5e6724b355e4f1739298a83"


### PR DESCRIPTION
The previous library had two memory leaks (missing frees for `malloc` and `getifaddrs`) and also dereferences a NULL pointer (`(struct ifaddrs).ifa_addr`) when an interface is layer 3 only (like Wireguard interfaces on Linux).